### PR TITLE
fix: compatibility issues with upcoming v1.13.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "validator": "^11.0.0"
   },
   "nbbpm": {
-    "compatibility": "^1.10.0"
+    "compatibility": "^1.13.0"
   }
 }

--- a/src/lib/controllers.js
+++ b/src/lib/controllers.js
@@ -1,4 +1,4 @@
-import { promisify as p, callbackify } from 'util';
+import { callbackify } from 'util';
 import { getEvent, escapeEvent } from './event';
 import { canViewPost } from './privileges';
 import eventTemplate from './templates';
@@ -8,8 +8,8 @@ import { getSetting, getSettings, setSettings } from './settings';
 const privileges = require.main.require('./src/privileges');
 const categories = require.main.require('./src/categories');
 
-const getAllCategoryFields = p(categories.getAllCategoryFields);
-const filterCids = p(privileges.categories.filterCids);
+const { getAllCategoryFields } = categories;
+const { filterCids } = privileges.categories;
 
 /* eslint-disable */
 function shadeColor2(color, percent) {

--- a/src/lib/event.js
+++ b/src/lib/event.js
@@ -1,4 +1,3 @@
-import { promisify as p } from 'util';
 import validator from 'validator';
 import { removeAll as removeAllResponses } from './responses';
 
@@ -6,19 +5,19 @@ const db = require.main.require('./src/database');
 const plugins = require.main.require('./src/plugins');
 const posts = require.main.require('./src/posts');
 
-const sortedSetAdd = p(db.sortedSetAdd);
-const sortedSetRemove = p(db.sortedSetRemove);
-const getSortedSetRangeByScore = p(db.getSortedSetRangeByScore);
-const getSortedSetRange = p(db.getSortedSetRange);
-// const getObjectsFields = p(db.getObjectsFields);
-const setObject = p(db.setObject);
-const getObject = p(db.getObject);
-const getObjects = p(db.getObjects);
-const deleteKey = p(db.delete);
-const exists = p(db.exists);
-const fireHook = p(plugins.fireHook);
-const getCidsByPids = p(posts.getCidsByPids);
-const getCidByPid = p(posts.getCidByPid);
+const { sortedSetAdd } = db;
+const { sortedSetRemove } = db;
+const { getSortedSetRangeByScore } = db;
+const { getSortedSetRange } = db;
+// const getObjectsFields = db.getObjectsFields;
+const { setObject } = db;
+const { getObject } = db;
+const { getObjects } = db;
+const deleteKey = db.delete;
+const { exists } = db;
+const { fireHook } = plugins;
+const { getCidsByPids } = posts;
+const { getCidByPid } = posts;
 
 const listKey = 'plugins:calendar:events';
 const listByEndKey = `${listKey}:byEnd`;

--- a/src/lib/postSave.js
+++ b/src/lib/postSave.js
@@ -1,5 +1,5 @@
 import validator from 'validator';
-import { promisify as p, callbackify } from 'util';
+import { callbackify } from 'util';
 
 import parse, { inPost } from './parse';
 import { canPostEvent, canPostMandatoryEvent } from './privileges';
@@ -12,8 +12,8 @@ const plugins = require.main.require('./src/plugins');
 const topics = require.main.require('./src/topics');
 const winston = require.main.require('winston');
 
-const fireHook = p(plugins.fireHook);
-const getTopicField = p(topics.getTopicField);
+const { fireHook } = plugins;
+const { getTopicField } = topics;
 
 const isMainPost = async ({ pid, tid }) => {
   const mainPid = await getTopicField(tid, 'mainPid');

--- a/src/lib/privileges.js
+++ b/src/lib/privileges.js
@@ -1,12 +1,11 @@
-import { promisify as p } from 'util';
 import { getSetting } from './settings';
 
 const privileges = require.main.require('./src/privileges');
 const posts = require.main.require('./src/posts');
-const privilegesPostCan = p(privileges.posts.can);
-const privilegesTopicCan = p(privileges.topics.can);
-const filterUidsByCid = p(privileges.categories.filterUids);
-const filterPids = p(privileges.posts.filter);
+const privilegesPostCan = privileges.posts.can;
+const privilegesTopicCan = privileges.topics.can;
+const filterUidsByCid = privileges.categories.filterUids;
+const filterPids = privileges.posts.filter;
 
 const privilegeNames = {
   canPost: 'plugin_calendar:event:post',
@@ -20,7 +19,7 @@ const canPostMandatoryEvent = (tid, uid) => privilegesTopicCan(
   tid,
   uid
 );
-const getCidByPid = p(posts.getCidByPid);
+const {getCidByPid} = posts;
 
 const canRespond = (pid, uid) => getSetting('respondIfCanReply')
   .then((respondIfCanReply) => {

--- a/src/lib/reminders.js
+++ b/src/lib/reminders.js
@@ -1,4 +1,4 @@
-import { promisify as p, callbackify } from 'util';
+import { callbackify } from 'util';
 import { getAll as getResponses, getUserResponse } from './responses';
 import { getEventsEndingAfter, escapeEvent } from './event';
 import { filterUidsByPid } from './privileges';
@@ -14,13 +14,13 @@ const emailer = require.main.require('./src/emailer');
 const nconf = require.main.require('nconf');
 const winston = require.main.require('winston');
 
-const createNotif = p(notifications.create);
-const pushNotif = p(notifications.push);
-const getPostFields = p(posts.getPostFields);
-const getUidsFromSet = p(user.getUidsFromSet);
-const sendEmail = p(emailer.send);
-const getUserSettings = p(user.getSettings);
-const getUserFields = p(user.getUserFields);
+const createNotif = notifications.create;
+const pushNotif = notifications.push;
+const { getPostFields } = posts;
+const { getUidsFromSet } = user;
+const sendEmail = emailer.send;
+const getUserSettings = user.getSettings;
+const { getUserFields } = user;
 
 const emailNotification = async ({ uid, event, message }) => {
   if (parseInt(meta.config.disableEmailSubscriptions, 10) === 1) {

--- a/src/lib/responses.js
+++ b/src/lib/responses.js
@@ -1,16 +1,15 @@
-import { promisify as p } from 'util';
 import { canRespond, canViewPost } from './privileges';
 import { listKey } from './event';
 
 const db = require.main.require('./src/database');
 const user = require.main.require('./src/user');
 
-const setAdd = p(db.setAdd);
-const setsRemove = p(db.setsRemove);
-const deleteAll = p(db.deleteAll);
-const getSetsMembers = p(db.getSetsMembers);
-const isSetMember = p(db.isSetMember);
-const getUsersFields = p(user.getUsersFields);
+const { setAdd } = db;
+const { setsRemove } = db;
+const { deleteAll } = db;
+const { getSetsMembers } = db;
+const { isSetMember } = db;
+const { getUsersFields } = user;
 
 const values = ['yes', 'maybe', 'no'];
 

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -1,10 +1,8 @@
-import { promisify as p } from 'util';
-
 const db = require.main.require('./src/database');
 
-const getObject = p(db.getObject);
-const getObjectField = p(db.getObjectField);
-const setObject = p(db.setObject);
+const { getObject } = db;
+const { getObjectField } = db;
+const { setObject } = db;
 
 const convert = {
   checkingInterval: x => parseInt(x, 10) || 1000 * 60 * 5,

--- a/src/lib/sockets.js
+++ b/src/lib/sockets.js
@@ -1,4 +1,4 @@
-import { promisify as p, callbackify } from 'util';
+import { callbackify } from 'util';
 import { getAll as getAllResponses, submitResponse, getUserResponse } from './responses';
 import { getEventsByDate, escapeEvent } from './event';
 import { filterByPid, privilegeNames } from './privileges';
@@ -11,12 +11,12 @@ const posts = require.main.require('./src/posts');
 const topics = require.main.require('./src/topics');
 
 const can = {
-  posts: p(privileges.posts.can),
-  topics: p(privileges.topics.can),
-  categories: p(privileges.categories.can),
+  posts: privileges.posts.can,
+  topics: privileges.topics.can,
+  categories: privileges.categories.can,
 };
-const tidFromPid = p((pid, cb) => posts.getPostField(pid, 'tid', cb));
-const topicIsDeleted = p((tid, cb) => topics.getTopicField(tid, 'deleted', cb));
+const tidFromPid = (pid, cb) => posts.getPostField(pid, 'tid', cb);
+const topicIsDeleted = (tid, cb) => topics.getTopicField(tid, 'deleted', cb);
 
 pluginSockets.calendar = {};
 pluginSockets.calendar.canPostEvent = callbackify(async ({ uid }, { pid, tid, cid, isMain }) => {

--- a/src/lib/sockets.js
+++ b/src/lib/sockets.js
@@ -19,7 +19,7 @@ const tidFromPid = (pid, cb) => posts.getPostField(pid, 'tid', cb);
 const topicIsDeleted = (tid, cb) => topics.getTopicField(tid, 'deleted', cb);
 
 pluginSockets.calendar = {};
-pluginSockets.calendar.canPostEvent = callbackify(async ({ uid }, { pid, tid, cid, isMain }) => {
+pluginSockets.calendar.canPostEvent = async ({ uid }, { pid, tid, cid, isMain }) => {
   const neither = {
     canPost: false,
     canPostMandatory: false,
@@ -59,7 +59,7 @@ pluginSockets.calendar.canPostEvent = callbackify(async ({ uid }, { pid, tid, ci
     canPost,
     canPostMandatory,
   };
-});
+};
 
 const getAllResponsesCb = callbackify(getAllResponses);
 const submitResponseCb = callbackify(submitResponse);


### PR DESCRIPTION
* `util.promisify/p()` not required on all core methods now
* Needs double-checking to make sure I didn't derp anything (turns out callbackify was needed)